### PR TITLE
Add dependency gettext in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,11 @@ These dependencies must be present before building
  - `gtk+-3.0`
  - `granite`
  - `meson`
+ - `gettext`
 
  **You can install these on a Ubuntu-based system by executing this command:**
 
- `sudo apt install valac libgranite-dev meson`
+ `sudo apt install valac libgranite-dev meson gettext`
 
  ### Building
 ```


### PR DESCRIPTION
Add dependency gettext because there was the error < po/meson.build:1:5: ERROR:  Can not do gettext because xgettext is not installed. > .