### PR TITLE
Use “its” instead of “it's” whenever the possessive is intended

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ![screenshot](Screenshot.png)
 
-AppEditor allows you to edit application entries in the application menu. Some of it's features include:
+AppEditor allows you to edit application entries in the application menu. Some of its features include:
 
 * Hide and show applications from the application menu
 * Create new application entries

--- a/data/com.github.donadigo.appeditor.appdata.xml.in
+++ b/data/com.github.donadigo.appeditor.appdata.xml.in
@@ -84,7 +84,7 @@
           </ul>
         <p>Fixed:</p>
           <ul>
-            <li>Fixed crashes when saving an entry with an equal sign in it's command line property</li>
+            <li>Fixed crashes when saving an entry with an equal sign in its command line property</li>
             <li>Sometimes deleting a local entry would cause it to stay in the sidebar until the next launch</li>
             <li>Sometimes creating a new entry caused a crash</li>
             <li>The page would not update after saving the entry</li>

--- a/po/ca.po
+++ b/po/ca.po
@@ -149,7 +149,7 @@ msgstr "Secció «Avançat» nova: permet afegir la clau «Utilitza notificacion
 
 #: data/com.github.donadigo.appeditor.appdata.xml.in:72
 msgid ""
-"Fixed crashes when saving an entry with an equal sign in it's command line "
+"Fixed crashes when saving an entry with an equal sign in its command line "
 "property"
 msgstr ""
 "S’han reparat les fallides quan es desava una entrada amb un signe igual a "
@@ -253,7 +253,7 @@ msgid "Visibility"
 msgstr "Visibilitat"
 
 #: src/AppInfoView.vala:147
-msgid "Program to execute along with it's arguments"
+msgid "Program to execute along with its arguments"
 msgstr "Programa que executar i els seus arguments"
 
 #: src/AppInfoView.vala:153

--- a/po/com.github.donadigo.appeditor.pot
+++ b/po/com.github.donadigo.appeditor.pot
@@ -139,7 +139,7 @@ msgstr ""
 
 #: data/com.github.donadigo.appeditor.appdata.xml.in:72
 msgid ""
-"Fixed crashes when saving an entry with an equal sign in it's command line "
+"Fixed crashes when saving an entry with an equal sign in its command line "
 "property"
 msgstr ""
 
@@ -235,7 +235,7 @@ msgid "Visibility"
 msgstr ""
 
 #: src/AppInfoView.vala:147
-msgid "Program to execute along with it's arguments"
+msgid "Program to execute along with its arguments"
 msgstr ""
 
 #: src/AppInfoView.vala:153

--- a/po/de.po
+++ b/po/de.po
@@ -142,7 +142,7 @@ msgstr ""
 
 #: data/com.github.donadigo.appeditor.appdata.xml.in:72
 msgid ""
-"Fixed crashes when saving an entry with an equal sign in it's command line "
+"Fixed crashes when saving an entry with an equal sign in its command line "
 "property"
 msgstr ""
 
@@ -243,7 +243,7 @@ msgid "Visibility"
 msgstr "Sichtbarkeit"
 
 #: src/AppInfoView.vala:147
-msgid "Program to execute along with it's arguments"
+msgid "Program to execute along with its arguments"
 msgstr "Auszuführendes Programm zusammen mit den Argumenten"
 
 #: src/AppInfoView.vala:153

--- a/po/es.po
+++ b/po/es.po
@@ -145,7 +145,7 @@ msgstr "Sección «Avanzado» nueva: adición de clave «Utiliza notificaciones�
 
 #: data/com.github.donadigo.appeditor.appdata.xml.in:72
 msgid ""
-"Fixed crashes when saving an entry with an equal sign in it's command line "
+"Fixed crashes when saving an entry with an equal sign in its command line "
 "property"
 msgstr ""
 "Se repararon los cuelgues al guardar una entrada con un signo de igualdad en "
@@ -250,7 +250,7 @@ msgid "Visibility"
 msgstr "Visibilidad"
 
 #: src/AppInfoView.vala:147
-msgid "Program to execute along with it's arguments"
+msgid "Program to execute along with its arguments"
 msgstr "Programa que ejecutar y sus argumentos"
 
 #: src/AppInfoView.vala:153

--- a/po/fr.po
+++ b/po/fr.po
@@ -144,7 +144,7 @@ msgstr ""
 
 #: data/com.github.donadigo.appeditor.appdata.xml.in:72
 msgid ""
-"Fixed crashes when saving an entry with an equal sign in it's command line "
+"Fixed crashes when saving an entry with an equal sign in its command line "
 "property"
 msgstr ""
 
@@ -238,7 +238,7 @@ msgid "Visibility"
 msgstr "Visibilité"
 
 #: src/AppInfoView.vala:147
-msgid "Program to execute along with it's arguments"
+msgid "Program to execute along with its arguments"
 msgstr "Application à exécuter avec ses arguments"
 
 #: src/AppInfoView.vala:153

--- a/po/it.po
+++ b/po/it.po
@@ -150,7 +150,7 @@ msgstr "Nuova sezione \"Avanzate\" : Aggiunto \"Usa Notifiche\""
 
 #: data/com.github.donadigo.appeditor.appdata.xml.in:72
 msgid ""
-"Fixed crashes when saving an entry with an equal sign in it's command line "
+"Fixed crashes when saving an entry with an equal sign in its command line "
 "property"
 msgstr ""
 "Risolti i crash durante il salvateggio di una voce con presente un segno \"="
@@ -253,7 +253,7 @@ msgid "Visibility"
 msgstr "Visibilità"
 
 #: src/AppInfoView.vala:147
-msgid "Program to execute along with it's arguments"
+msgid "Program to execute along with its arguments"
 msgstr "Programma da eseguire insieme ai suoi argomenti"
 
 #: src/AppInfoView.vala:153

--- a/po/ja.po
+++ b/po/ja.po
@@ -145,7 +145,7 @@ msgstr ""
 
 #: data/com.github.donadigo.appeditor.appdata.xml.in:72
 msgid ""
-"Fixed crashes when saving an entry with an equal sign in it's command line "
+"Fixed crashes when saving an entry with an equal sign in its command line "
 "property"
 msgstr ""
 
@@ -243,7 +243,7 @@ msgid "Visibility"
 msgstr "表示"
 
 #: src/AppInfoView.vala:147
-msgid "Program to execute along with it's arguments"
+msgid "Program to execute along with its arguments"
 msgstr "引数と一緒に実行するプログラム"
 
 #: src/AppInfoView.vala:153

--- a/po/lt.po
+++ b/po/lt.po
@@ -141,7 +141,7 @@ msgstr ""
 
 #: data/com.github.donadigo.appeditor.appdata.xml.in:72
 msgid ""
-"Fixed crashes when saving an entry with an equal sign in it's command line "
+"Fixed crashes when saving an entry with an equal sign in its command line "
 "property"
 msgstr ""
 
@@ -235,7 +235,7 @@ msgid "Visibility"
 msgstr "Matomumas"
 
 #: src/AppInfoView.vala:147
-msgid "Program to execute along with it's arguments"
+msgid "Program to execute along with its arguments"
 msgstr "Programą kurią paleisti, kartu su jos argumentais"
 
 #: src/AppInfoView.vala:153

--- a/po/nl_NL.po
+++ b/po/nl_NL.po
@@ -150,7 +150,7 @@ msgstr "Nieuwe sectie 'Geavanceerd': 'Meldingen gebruiken' toegevoegd"
 
 #: data/com.github.donadigo.appeditor.appdata.xml.in:72
 msgid ""
-"Fixed crashes when saving an entry with an equal sign in it's command line "
+"Fixed crashes when saving an entry with an equal sign in its command line "
 "property"
 msgstr ""
 "Crashes opgelost omtrent het opslaan van een item met een '='-teken in de "
@@ -251,7 +251,7 @@ msgid "Visibility"
 msgstr "Zichtbaarheid"
 
 #: src/AppInfoView.vala:147
-msgid "Program to execute along with it's arguments"
+msgid "Program to execute along with its arguments"
 msgstr "Het uit te voeren programma en evt. argumenten"
 
 #: src/AppInfoView.vala:153

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -140,7 +140,7 @@ msgstr ""
 
 #: data/com.github.donadigo.appeditor.appdata.xml.in:72
 msgid ""
-"Fixed crashes when saving an entry with an equal sign in it's command line "
+"Fixed crashes when saving an entry with an equal sign in its command line "
 "property"
 msgstr ""
 
@@ -240,7 +240,7 @@ msgid "Visibility"
 msgstr "Visibilidade"
 
 #: src/AppInfoView.vala:147
-msgid "Program to execute along with it's arguments"
+msgid "Program to execute along with its arguments"
 msgstr "Aplicativo para executar com seus argumentos"
 
 #: src/AppInfoView.vala:153

--- a/po/ru.po
+++ b/po/ru.po
@@ -142,7 +142,7 @@ msgstr ""
 
 #: data/com.github.donadigo.appeditor.appdata.xml.in:72
 msgid ""
-"Fixed crashes when saving an entry with an equal sign in it's command line "
+"Fixed crashes when saving an entry with an equal sign in its command line "
 "property"
 msgstr ""
 
@@ -242,7 +242,7 @@ msgid "Visibility"
 msgstr "Отображение"
 
 #: src/AppInfoView.vala:147
-msgid "Program to execute along with it's arguments"
+msgid "Program to execute along with its arguments"
 msgstr "Путь к программе вместе с агументами запуска"
 
 #: src/AppInfoView.vala:153

--- a/po/tr.po
+++ b/po/tr.po
@@ -148,7 +148,7 @@ msgstr ""
 
 #: data/com.github.donadigo.appeditor.appdata.xml.in:72
 msgid ""
-"Fixed crashes when saving an entry with an equal sign in it's command line "
+"Fixed crashes when saving an entry with an equal sign in its command line "
 "property"
 msgstr ""
 "Komut satırı özelliğinde bir girişin eşit işareti ile kaydedilmesi düzeltildi"
@@ -250,7 +250,7 @@ msgid "Visibility"
 msgstr "Görünürlük"
 
 #: src/AppInfoView.vala:147
-msgid "Program to execute along with it's arguments"
+msgid "Program to execute along with its arguments"
 msgstr "Argümanları ile birlikte yürütmek için program"
 
 #: src/AppInfoView.vala:153

--- a/src/AppInfoView.vala
+++ b/src/AppInfoView.vala
@@ -144,7 +144,7 @@ public class AppEditor.AppInfoView : Gtk.Box {
         cmdline_entry = new PersistentPlaceholderEntry ();
         cmdline_entry.width_request = 300;
         cmdline_entry.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
-        cmdline_entry.placeholder_text = _("Program to execute along with it's arguments");
+        cmdline_entry.placeholder_text = _("Program to execute along with its arguments");
         cmdline_entry.changed.connect (on_cmdline_entry_changed);
 
         path_entry = new PersistentPlaceholderEntry ();


### PR DESCRIPTION
Use “its” for possessive (referring to something that belongs to “it”) rather than “it’s,” which is the contraction for “it is.”