### PR TITLE
Fix translation is not loaded in Flatpak

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,17 +1,22 @@
 project('com.github.donadigo.appeditor', ['vala', 'c'],
-        version: '1.1.1')
+        version: '1.1.3')
 
 i18n = import('i18n')
 gnome = import('gnome')
 
-conf = configuration_data()
-conf.set_quoted('GETTEXT_PACKAGE', meson.project_name())
-configure_file(output: 'config.h', configuration: conf)
-config_h_dir = include_directories('.')
+add_project_arguments(
+    '-DGETTEXT_PACKAGE="@0@"'.format(meson.project_name()),
+    language: 'c'
+)
 
-c_args = [
-  '-include', 'config.h'
-]
+conf = configuration_data()
+conf.set_quoted('LOCALEDIR', get_option('prefix') / get_option('localedir'))
+conf.set_quoted('GETTEXT_PACKAGE', meson.project_name())
+config_file = configure_file(
+    input: 'src' / 'Config.vala.in',
+    output: '@BASENAME@',
+    configuration: conf
+)
 
 vala = meson.get_compiler('vala')
 vala_flags = []
@@ -41,6 +46,7 @@ asresources = gnome.compile_resources(
 
 executable(
     meson.project_name(),
+    config_file,
     'src/Application.vala',
     'src/MainWindow.vala',
     'src/AppSourceList.vala',
@@ -62,7 +68,6 @@ executable(
     'src/IconRow.vala',
     'src/Constants.vala',
     asresources,
-    c_args: c_args,
     dependencies: [
         deps
     ],

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -34,6 +34,11 @@ public class AppEditor.Application : Gtk.Application {
         application_id = "com.github.donadigo.appeditor";
         add_main_option_entries (OPTIONS);
 
+        Intl.setlocale (LocaleCategory.ALL, "");
+        Intl.bindtextdomain (GETTEXT_PACKAGE, LOCALEDIR);
+        Intl.bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
+        Intl.textdomain (GETTEXT_PACKAGE);
+
         AppDirectoryScanner.init ();
         var manager = DesktopAppManager.get_default ();
         manager.load ();

--- a/src/Config.vala.in
+++ b/src/Config.vala.in
@@ -1,0 +1,2 @@
+public const string GETTEXT_PACKAGE = @GETTEXT_PACKAGE@;
+public const string LOCALEDIR = @LOCALEDIR@;


### PR DESCRIPTION
## Before
![Screenshot from 2022-01-01 14-05-08](https://user-images.githubusercontent.com/26003928/147844337-c52cff22-b383-46df-92be-d6469a776f3a.png)

The app always displays in English, regardless of the system language (for me Japanese).

## After
![Screenshot from 2022-01-01 14-01-37](https://user-images.githubusercontent.com/26003928/147844335-039f719e-8757-4f11-b65e-7015464838c8.png)

The app now respects the system language.

This PR also bumps the project version defined in `meson.build`. Glad to see AppEditor came back into AppCenter again!
