### PR TITLE
Fix #121 (failure to compile with vala 0.55.1)

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -26,7 +26,7 @@ public class AppEditor.Application : Gtk.Application {
         return Gtk.check_version (3, 22, 0) == null;
     }
 
-    private static string? create_exec_filename;
+    public static string? create_exec_filename;
 
     private MainWindow? window = null;
 


### PR DESCRIPTION
Make `create_exec_filename public` so it is not less accessible than `OPTIONS`, the value of which contains it.