### PR TITLE
Fix deprecated top-level developer_name in AppData XML

### DIFF
--- a/data/com.github.donadigo.appeditor.appdata.xml.in
+++ b/data/com.github.donadigo.appeditor.appdata.xml.in
@@ -20,7 +20,7 @@
   <provides>
     <binary>com.github.donadigo.appeditor</binary>
   </provides>
-  <developer>
+  <developer id="com.donadigo">
     <name>Adam Bieńkowski</name>
   </developer>
   <url type="homepage">https://github.com/donadigo/appeditor</url>

--- a/data/com.github.donadigo.appeditor.appdata.xml.in
+++ b/data/com.github.donadigo.appeditor.appdata.xml.in
@@ -20,7 +20,9 @@
   <provides>
     <binary>com.github.donadigo.appeditor</binary>
   </provides>
-  <developer_name>Adam Bieńkowski</developer_name>
+  <developer>
+    <name>Adam Bieńkowski</name>
+  </developer>
   <url type="homepage">https://github.com/donadigo/appeditor</url>
   <url type="bugtracker">https://github.com/donadigo/appeditor/issues</url>
   <url type="help">https://github.com/donadigo/appeditor</url>


### PR DESCRIPTION
Use the `name` element in a developer `block` instead, as recommended by `appstreamcli` 1.0.0.

This fixes all warnings when validating the AppData XML file, although there are still informational messages:

```
I: com.github.donadigo.appeditor.desktop:31: description-first-para-too-short
     Edit application entries shown in application menu and their properties.
   The first `description/p` paragraph of this component might be too short (< 80 characters).
   Please consider starting with a longer paragraph to improve how the description looks like in
   software centers and to provide more detailed information on this component immediately in the
   first paragraph.

I: com.github.donadigo.appeditor.desktop:92: developer-id-missing
   The `developer` element is missing an `id` property, containing a unique string ID for the
   developer. Consider adding a unique ID.

I: com.github.donadigo.appeditor.desktop:~: desktop-app-launchable-omitted
   This `desktop-application` component has no `desktop-id` launchable tag, however it contains all
   the necessary information to display the application. The omission of the launchable entry means
   that this application can not be launched directly from installers or software centers. If this
   is intended, this information can be ignored, otherwise it is strongly recommended to add a
   launchable tag as well.
```